### PR TITLE
Update to v1.9.2

### DIFF
--- a/recipe/build-core.bat
+++ b/recipe/build-core.bat
@@ -1,9 +1,7 @@
-@REM These let Bazel know which Visual Studio it should use.
-set "BAZEL_VC=%VSINSTALLDIR%VC"
-set "BAZEL_VS=%VSINSTALLDIR%"
-
 cd python
 set SKIP_THIRDPARTY_INSTALL=1
+set IS_AUTOMATED_BUILD=1
+set "BAZEL_SH=%BUILD_PREFIX%\Library\usr\bin\bash.exe"
 "%PYTHON%" setup.py install
 rem remember the return code
 set RETCODE=%ERRORLEVEL%

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -18,3 +18,6 @@ grep -lR ELF build/ | xargs chmod +w
 bazel "--output_user_root=$SRC_DIR/../bazel-root" "--output_base=$SRC_DIR/../b-o" clean
 bazel "--output_user_root=$SRC_DIR/../bazel-root" "--output_base=$SRC_DIR/../b-o" shutdown
 rm -rf "$SRC_DIR/../b-o" "$SRC_DIR/../bazel-root"
+# this is needed because on many build systems the cache is actually under /root.
+# but this may not always be true/allowed, hence the or operation.
+rm -rf /root/.cache/bazel || true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,13 @@
-cuda_compiler_version:                     
-  - None
-docker_image:
-  - quay.io/condaforge/linux-anvil-cos7-x86_64
-cudnn:
-  - undefined
-cdt_name:
-  - cos7
+cuda_compiler_version:                            # [linux and x86_64]
+  - None                                          # [linux and x86_64]
+docker_image:                                     # [linux and x86_64]
+  - quay.io/condaforge/linux-anvil-cos7-x86_64    # [linux and x86_64]
+cudnn:                                            # [linux and x86_64]
+  - undefined                                     # [linux and x86_64]
+cdt_name:                                         # [linux and x86_64]
+  - cos7                                          # [linux and x86_64]
+
+c_compiler:                                       # [win]
+- vs2019                                          # [win]
+cxx_compiler:                                     # [win]
+- vs2019                                          # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,8 @@
-cuda_compiler_version:                          # [linux64]
-  - None                                        # [linux64]
-docker_image:                                   # [linux64]
-  - quay.io/condaforge/linux-anvil-cos7-x86_64  # [linux64]
-cudnn:                                          # [linux64]
-  - undefined                                   # [linux64]
-cdt_name:                                       # [linux64]
-  - cos7                                        # [linux64]
+cuda_compiler_version:                     
+  - None
+docker_image:
+  - quay.io/condaforge/linux-anvil-cos7-x86_64
+cudnn:
+  - undefined
+cdt_name:
+  - cos7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.9.2" %}
 
 package:
   name: ray-packages
@@ -6,27 +6,19 @@ package:
 
 source:
   url: https://github.com/ray-project/ray/archive/ray-{{ version }}.tar.gz
-  sha256: b96a8d864b91dc1c2cfdc3d27602a3c9afaedbc7765330d6cba10c1f0ab56628
+  sha256: 33bd1afcfe2f8d0f416e80bf21e4b36fe6f9ec74c55b034a5581553270fdf8e8
   patches:
     - patches/0001-Do-not-force-pickle5-in-sys.path.patch
-    - patches/0002-Fix-redis-build-for-non-default-compiler-drivers.patch
     - patches/0003-Redis-deps-now-build-but-do-not-link.patch
     - patches/0004-Disable-making-non-core-entry-scripts.patch
-    - patches/0005-Contain-bazel-root-and-output-dir-right-above-SRC_DI.patch
-    - patches/0006-Do-not-crash-if-BAZEL_SH-not-set-on-Windows.patch
-    - patches/0007-Convert-symlinks-to-junctions-on-Windows-before-buil.patch
-    - patches/0008-Add-workaround-for-os.path.isdir-on-Windows.patch
-    - patches/0009-Include-process.h-for-getpid-explicitly-on-Windows.patch
     - patches/0010-Remove-all-dependencies-from-setup.py.patch
     - patches/0011-Ignore-warnings-in-event.cc-and-logging.cc.patch
-    - patches/0012-Disable-runfiles-on-windows.patch
     - patches/0013-Add-bazel-linkopts-libs.patch
-
+    - patches/0014-Fix-replace_symlinks_with_junctions.patch
 
 build:
   number: 0
-  skip: true  # [py<36]
-  # skip on MacOS as there's some weird compilation issue and I have no MacOS to develop on
+  skip: true  # [py<36 or py>39]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64
   skip: true  # [not ((linux or win) and x86_64)]
 
@@ -36,7 +28,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - git
-    - bazel <=3.7.2
+    - bazel >=4.2.1
     - cython >=0.29
     - curl
     - make           # [not win]
@@ -76,14 +68,13 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - bazel <=3.4.1  # [not win]
-        - bazel <3.7     # [win]
+        - bazel >=4.2.1
         - sysroot_linux-64 2.17  # [linux64]
         - curl
         - cython >=0.29
         - make      # [not win]
         - m2-make   # [win]
-        - python <3.10
+        - python  
       host:
         - python
         - pip
@@ -127,7 +118,7 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('ray-core', exact=True) }}
-        - aiohttp 3.7
+        - aiohttp >=3.7
         - aiohttp-cors
         - aioredis <2
         - colorful

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36 or py>39]
+  skip: true  # [py<36]
+  skip: true  # [py>39]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64
   skip: true  # [osx or (not x86_64)]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - bazel >=4.2.1
-        - sysroot_linux-64 2.17  # [linux64]
+        - sysroot_linux-64 2.17  # [linux and x86_64]
         - curl
         - cython >=0.29
         - make      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,13 +93,14 @@ outputs:
         - filelock
         - grpcio >=1.28.1
         - msgpack-python >=1.0.0, <2.0.0
-        - numpy >=1.16
+        - numpy >=1.16 # [py<39]
+        - numpy >=1.19.3 # [py>=39]
         - pickle5  # [py<38]
         - protobuf >=3.15.3
         - psutil
         - pyyaml
         - redis-py >=3.5.0
-        - setproctitle =1.1.10
+        - setproctitle =1.2.2
 
     test:
       imports:
@@ -120,9 +121,11 @@ outputs:
         - python
         - {{ pin_subpackage('ray-core', exact=True) }}
         - aiohttp >=3.7
+        - aiosignal
         - aiohttp-cors
         - aioredis <2
         - colorful
+        - frozenlist
         # gpustat-0.6.0 has a dependency which does not exist on Windows;
         # skip it there until gpustat is fixed as it is optional
         - gpustat  # [not win]
@@ -131,6 +134,7 @@ outputs:
         - opencensus
         - prometheus_client >=0.7.1
         - py-spy >=0.2.0
+        - smart_open
 
     test:
       imports:
@@ -170,7 +174,6 @@ outputs:
 
   - name: ray-dashboard
     build:
-      # Skipping this because for now.
       skip: true
       script:
         - cd python/ray/dashboard/client
@@ -301,7 +304,7 @@ outputs:
         - ray.tune
 
 about:
-  home: https://github.com/ray-project/ray
+  home: https://www.ray.io/
   license: Apache-2.0
   license_family: Apache
   license_file:
@@ -332,7 +335,7 @@ about:
   description: |
     Ray is a fast and simple framework for building and running
     distributed applications.
-  doc_url: https://ray.readthedocs.io/
+  doc_url: https://docs.ray.io/en/latest/
   dev_url: https://github.com/ray-project/ray
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ build:
   skip: true  # [py<36]
   skip: true  # [py>39]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64
-  skip: true  # [osx or (not x86_64)]
+  skip: true  # [osx]
+  skip: true  # [not (x86_64 or win)]
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   number: 0
   skip: true  # [py<36 or py>39]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64
-  skip: true  # [not ((linux or win) and x86_64)]
+  skip: true  # [osx or (not x86_64)]
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:
@@ -49,9 +49,9 @@ outputs:
         # autoscaler is completely disabled for now as it's missing a bunch of dependencies
         # and there's not much interest in adding them (yet).
         # autoscaler does not work on Windows, no point of building it; see below
-        #- {{ pin_subpackage('ray-autoscaler', exact=True) }}  # [not win]
+        # - {{ pin_subpackage('ray-autoscaler', exact=True) }}  # [not win]
         - {{ pin_subpackage('ray-dashboard', exact=True) }}
-        #- {{ pin_subpackage('ray-debug', exact=True) }}  # turned off for now, see below
+        # - {{ pin_subpackage('ray-debug', exact=True) }}  # turned off for now, see below
         - {{ pin_subpackage('ray-k8s', exact=True) }}
         - {{ pin_subpackage('ray-rllib', exact=True) }}
         - {{ pin_subpackage('ray-serve', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,7 +105,6 @@ outputs:
         - ray
         - ray._raylet
         - ray.actor
-        - ray.profiling
         - ray.runtime_context
         - ray.state
         - ray.worker
@@ -170,14 +169,16 @@ outputs:
 
   - name: ray-dashboard
     build:
+      # Skipping this because for now.
+      skip: true
       script:
-        - cd python/ray/new_dashboard/client
+        - cd python/ray/dashboard/client
         - npm install
         - npm ci
         - npm run build
         # not sure why this seems to get copied on windows but not linux...
-        - mkdir -p $SP_DIR/ray/new_dashboard/client             # [not win]
-        - cp -R ./build $SP_DIR/ray/new_dashboard/client/build  # [not win]
+        - mkdir -p $SP_DIR/ray/dashboard/client             # [not win]
+        - cp -R ./build $SP_DIR/ray/dashboard/client/build  # [not win]
     requirements:
       host:
         - nodejs
@@ -187,7 +188,7 @@ outputs:
         - {{ pin_subpackage('ray-default', exact=True) }}
     test:
       imports:
-        - ray.new_dashboard
+        - ray.dashboard
       commands:
         - python -c "import ray; ray.init(include_dashboard=True)"
 
@@ -281,6 +282,7 @@ outputs:
 
   - name: ray-tune
     build:
+      skip: true
       entry_points:
         - tune = ray.tune.scripts:cli
     requirements:

--- a/recipe/patches/0001-Do-not-force-pickle5-in-sys.path.patch
+++ b/recipe/patches/0001-Do-not-force-pickle5-in-sys.path.patch
@@ -1,7 +1,7 @@
-From ae9a5f4126221a93f58715fda105396881787581 Mon Sep 17 00:00:00 2001
+From 76df41d9f33447df2309183b0ad18f56c8fe788a Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 Date: Thu, 5 Nov 2020 12:04:25 +0300
-Subject: [PATCH 01/13] Do not force pickle5 in sys.path
+Subject: [PATCH 1/6] Do not force pickle5 in sys.path
 
 Signed-off-by: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Vasily Litvinov <vasilij.n.litvinov@intel.com>
  1 file changed, 6 deletions(-)
 
 diff --git a/python/ray/__init__.py b/python/ray/__init__.py
-index 3118cd19a..3a6601170 100644
+index 758356f1a..6702014c5 100644
 --- a/python/ray/__init__.py
 +++ b/python/ray/__init__.py
 @@ -34,12 +34,6 @@ def _configure_system():
@@ -26,5 +26,4 @@ index 3118cd19a..3a6601170 100644
      # initialized.
      thirdparty_files = os.path.join(
 -- 
-2.26.2
-
+2.30.1 (Apple Git-130)

--- a/recipe/patches/0003-Redis-deps-now-build-but-do-not-link.patch
+++ b/recipe/patches/0003-Redis-deps-now-build-but-do-not-link.patch
@@ -1,27 +1,28 @@
-From adbd2dba70497d8f2219ce97ee8510cc3df0e4b2 Mon Sep 17 00:00:00 2001
+From 52995c7fc6299a896fcc9e6b85a17a652771b46e Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
-Date: Fri, 6 Nov 2020 00:55:05 +0300
-Subject: [PATCH 03/13] Redis deps now build but do not link
-
-Includes update for redis-6.0.9
+Date: Fri, 3 Dec 2021 10:46:36 -0800
+Subject: [PATCH 2/6] Redis deps now build but do not link
 
 Signed-off-by: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>
+Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
 ---
- bazel/BUILD.redis                      | 12 ++++-
+ bazel/BUILD.redis                      | 13 ++++-
  bazel/ray_deps_setup.bzl               |  1 +
  thirdparty/patches/redis-deps-ar.patch | 74 ++++++++++++++++++++++++++
- 3 files changed, 85 insertions(+), 2 deletions(-)
+ 3 files changed, 86 insertions(+), 2 deletion(-)
  create mode 100644 thirdparty/patches/redis-deps-ar.patch
 
 diff --git a/bazel/BUILD.redis b/bazel/BUILD.redis
-index 9ec69d433..06d79b72a 100644
+index f488d607f..234d72e68 100644
 --- a/bazel/BUILD.redis
 +++ b/bazel/BUILD.redis
-@@ -15,12 +15,16 @@ genrule(
+@@ -14,13 +14,17 @@ genrule(
+         "redis-cli",
      ],
      cmd = """
-         export CC=$(CC)
+-        unset CC LDFLAGS CXX CXXFLAGS
++        export CC=$(CC)
 +        export CFLAGS=$(CC_FLAGS)
 +        export AR=$${CC/gnu-cc/gnu-ar}
 +        export NM=$${CC/gnu-cc/gnu-nm}
@@ -36,24 +37,24 @@ index 9ec69d433..06d79b72a 100644
          mv "$${tmpdir}"/src/redis-server $(location redis-server)
          chmod +x $(location redis-server)
          mv "$${tmpdir}"/src/redis-cli $(location redis-cli)
-@@ -28,7 +32,11 @@ genrule(
+@@ -28,6 +32,11 @@ genrule(
          rm -r -f -- "$${tmpdir}"
      """,
      visibility = ["//visibility:public"],
--    toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 +    toolchains = [
 +        "@bazel_tools//tools/cpp:current_cc_toolchain",
 +        "@bazel_tools//tools/cpp:current_cc_host_toolchain",
 +        "@bazel_tools//tools/cpp:cc_flags",
 +    ],
+     tags = ["local"],
  )
- 
+
  # This library is for internal hiredis use, because hiredis assumes a
 diff --git a/bazel/ray_deps_setup.bzl b/bazel/ray_deps_setup.bzl
-index 33afb91f7..30327d5e7 100644
+index 1925aedfa..15470202e 100644
 --- a/bazel/ray_deps_setup.bzl
 +++ b/bazel/ray_deps_setup.bzl
-@@ -91,6 +91,7 @@ def ray_deps_setup():
+@@ -99,6 +99,7 @@ def ray_deps_setup():
          sha256 = "900cb82227bac58242c9b7668e7113cd952253b256fe04bbdab1b78979cf255a",
          patches = [
              "//thirdparty/patches:redis-quiet.patch",
@@ -142,5 +143,5 @@ index 000000000..36497c4b6
 +2.11.0
 +
 -- 
-2.26.2
+2.30.1 (Apple Git-130)
 

--- a/recipe/patches/0004-Disable-making-non-core-entry-scripts.patch
+++ b/recipe/patches/0004-Disable-making-non-core-entry-scripts.patch
@@ -1,17 +1,17 @@
-From e1c84846778801517375cc282aa6bcb38075f212 Mon Sep 17 00:00:00 2001
+From 06ed4ea25b4aefc40b515584485eebefbd6f2837 Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 Date: Tue, 10 Nov 2020 23:26:35 +0300
-Subject: [PATCH 04/13] Disable making non-core entry scripts
+Subject: [PATCH 3/6] Disable making non-core entry scripts
 
 ---
  python/setup.py | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/python/setup.py b/python/setup.py
-index b8671970c..987c2c8b1 100644
+index 056c1ef05..7ebc0a894 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -534,10 +534,10 @@ setuptools.setup(
+@@ -666,10 +666,10 @@ setuptools.setup(
      entry_points={
          "console_scripts": [
              "ray=ray.scripts.scripts:main",
@@ -27,5 +27,4 @@ index b8671970c..987c2c8b1 100644
      },
      include_package_data=True,
 -- 
-2.26.2
-
+2.30.1 (Apple Git-130)

--- a/recipe/patches/0010-Remove-all-dependencies-from-setup.py.patch
+++ b/recipe/patches/0010-Remove-all-dependencies-from-setup.py.patch
@@ -1,31 +1,39 @@
-From 4118ed9f605be75a83e870725e04798c436db896 Mon Sep 17 00:00:00 2001
+From 5ba4c3b61656a28326469356f286d64e29a1e957 Mon Sep 17 00:00:00 2001
 From: Kai Fricke <kai@anyscale.com>
-Date: Tue, 24 Aug 2021 09:57:05 +0200
-Subject: [PATCH 10/13] Remove all dependencies from setup.py
+Date: Fri, 3 Dec 2021 10:55:23 -0800
+Subject: [PATCH 4/6] Remove all dependencies from setup.py
 
+Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
 ---
- python/setup.py | 52 ++++++++-----------------------------------------
- 1 file changed, 8 insertions(+), 44 deletions(-)
+ python/setup.py | 61 ++++++++-----------------------------------------
+ 1 file changed, 9 insertions(+), 52 deletions(-)
 
 diff --git a/python/setup.py b/python/setup.py
-index db250ed3c..021499aee 100644
+index c361a6880..3dc3e5777 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -161,41 +161,17 @@ ray_files += [
+@@ -192,32 +192,12 @@ ray_files += [
  # in this directory
  if setup_spec.type == SetupType.RAY:
      setup_spec.extras = {
+-        "data": [
+-            "pandas",
+-            "pyarrow>=4.0.1",
+-            "fsspec",
+-        ],
 -        "default": [
--            "aiohttp",  # noqa
--            "aiohttp_cors",  # noqa
--            "aioredis < 2",  # noqa
--            "colorful",  # noqa
--            "py-spy >= 0.2.0",  # noqa
--            "jsonschema",  # noqa
--            "requests",  # noqa
--            "gpustat",  # noqa
--            "opencensus",  # noqa
--            "prometheus_client >= 0.7.1",  # noqa
+-            "aiohttp >= 3.7",
+-            "aiosignal",
+-            "aiohttp_cors",
+-            "aioredis < 2",
+-            "colorful",
+-            "frozenlist",
+-            "py-spy >= 0.2.0",
+-            "requests",
+-            "gpustat >= 1.0.0b1",  # for windows
+-            "opencensus",
+-            "prometheus_client >= 0.7.1",
+-            "smart_open"
 -        ],
 -        "serve": ["uvicorn", "requests", "starlette", "fastapi"],
 -        "tune": ["pandas", "tabulate", "tensorboardX>=1.9", "requests"],
@@ -34,13 +42,16 @@ index db250ed3c..021499aee 100644
 -            "opentelemetry-api==1.1.0", "opentelemetry-sdk==1.1.0",
 -            "opentelemetry-exporter-otlp==1.1.0"
 -        ],
++        "data": [],
 +        "default": [],
 +        "serve": [],
 +        "tune": [],
 +        "k8s": [],
 +        "observability": [],
-         "cpp": ["ray-cpp==" + setup_spec.version]
      }
+ 
+     if sys.version_info >= (3, 7):
+@@ -234,17 +214,7 @@ if setup_spec.type == SetupType.RAY:
      if sys.version_info >= (3, 7, 0):
          setup_spec.extras["k8s"].append("kopf")
  
@@ -59,7 +70,7 @@ index db250ed3c..021499aee 100644
  
      setup_spec.extras["all"] = list(
          set(chain.from_iterable(setup_spec.extras.values())))
-@@ -204,19 +180,7 @@ if setup_spec.type == SetupType.RAY:
+@@ -253,20 +223,7 @@ if setup_spec.type == SetupType.RAY:
  # should be carefully curated. If you change it, please reflect
  # the change in the matching section of requirements/requirements.txt
  if setup_spec.type == SetupType.RAY:
@@ -69,6 +80,7 @@ index db250ed3c..021499aee 100644
 -        "dataclasses; python_version < '3.7'",
 -        "filelock",
 -        "grpcio >= 1.28.1",
+-        "jsonschema",
 -        "msgpack >= 1.0.0, < 2.0.0",
 -        "numpy >= 1.16; python_version < '3.9'",
 -        "numpy >= 1.19.3; python_version >= '3.9'",
@@ -80,7 +92,7 @@ index db250ed3c..021499aee 100644
  
  
  def is_native_windows_or_msys():
-@@ -601,7 +565,7 @@ setuptools.setup(
+@@ -710,7 +667,7 @@ setuptools.setup(
      # The BinaryDistribution argument triggers build_ext.
      distclass=BinaryDistribution,
      install_requires=setup_spec.install_requires,
@@ -90,5 +102,5 @@ index db250ed3c..021499aee 100644
      entry_points={
          "console_scripts": [
 -- 
-2.26.2
+2.30.1 (Apple Git-130)
 

--- a/recipe/patches/0011-Ignore-warnings-in-event.cc-and-logging.cc.patch
+++ b/recipe/patches/0011-Ignore-warnings-in-event.cc-and-logging.cc.patch
@@ -1,20 +1,20 @@
-From ca5a07d1de602eca1d38b41561a84711e57b7096 Mon Sep 17 00:00:00 2001
+From b8c4c38817bb88a84e3cf8b266bb36bfd9485438 Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
-Date: Wed, 11 Nov 2020 01:08:16 +0300
-Subject: [PATCH 11/13] Ignore warnings in event.cc and logging.cc
+Date: Fri, 3 Dec 2021 10:59:10 -0800
+Subject: [PATCH 5/6] Ignore warnings in event.cc and logging.cc
 
 Signed-off-by: Vasily Litvinov <vasilij.n.litvinov@intel.com>
-Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>
+Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
 ---
  .bazelrc | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/.bazelrc b/.bazelrc
-index a8740c684..07dce40ed 100644
+index 161c65148..8c15ce5cf 100644
 --- a/.bazelrc
 +++ b/.bazelrc
-@@ -37,6 +37,9 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
- build:msvc     --per_file_copt="-\\.(asm|S)$@-WX"
+@@ -38,6 +38,9 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
+ build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
  # Ignore warnings for protobuf generated files and external projects.
  build --per_file_copt="\\.pb\\.cc$@-w"
 +# Ignore one specific warning
@@ -24,5 +24,4 @@ index a8740c684..07dce40ed 100644
  #build --per_file_copt="external/.*@-Wno-unused-result"
  # Ignore minor warnings for host tools, which we generally can't control
 -- 
-2.26.2
-
+2.30.1 (Apple Git-130)

--- a/recipe/patches/0013-Add-bazel-linkopts-libs.patch
+++ b/recipe/patches/0013-Add-bazel-linkopts-libs.patch
@@ -1,17 +1,18 @@
-From 2807bbc926212d2486a8f127cb2cb07194893377 Mon Sep 17 00:00:00 2001
+From b5fe0fa9b38222be0753e594f152cb94056e36e3 Mon Sep 17 00:00:00 2001
 From: Kai Fricke <kai@anyscale.com>
-Date: Fri, 6 Aug 2021 12:36:05 +0100
-Subject: [PATCH 13/13] Add bazel linkopts/libs
+Date: Fri, 3 Dec 2021 11:04:33 -0800
+Subject: [PATCH 6/6] Add bazel linkopts/libs
 
+Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
 ---
  python/setup.py | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/python/setup.py b/python/setup.py
-index a0cc87c45..77fb018d7 100644
+index f70018f27..565237825 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -335,6 +335,8 @@ def build(build_python, build_java, build_cpp):
+@@ -380,6 +380,8 @@ def build(build_python, build_java, build_cpp):
          raise OSError(msg)
  
      bazel_env = dict(os.environ, PYTHON3_BIN_PATH=sys.executable)
@@ -19,7 +20,6 @@ index a0cc87c45..77fb018d7 100644
 +    bazel_env.setdefault("BAZEL_LINKLIBS", "-l%:libstdc++.a")
  
      if is_native_windows_or_msys():
-         replace_symlinks_with_junctions()
+         SHELL = bazel_env.get("SHELL")
 -- 
-2.26.2
-
+2.30.1 (Apple Git-130)

--- a/recipe/patches/0014-Fix-replace_symlinks_with_junctions.patch
+++ b/recipe/patches/0014-Fix-replace_symlinks_with_junctions.patch
@@ -1,0 +1,35 @@
+From 495a4d5d5056d7bbf6aac1f0e6816ebc5899ee4b Mon Sep 17 00:00:00 2001
+From: Jiajun Yao <jjyao@anyscale.com>
+Date: Tue, 18 Jan 2022 09:40:46 -0800
+Subject: [PATCH 8/8] Fix replace_symlinks_with_junctions
+
+Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
+---
+ python/setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/setup.py b/python/setup.py
+index 80613e107..9e089329d 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -314,7 +314,7 @@ def replace_symlinks_with_junctions():
+ 
+     # Update this list if new symlinks are introduced to the source tree
+     _LINKS = {
+-        r"ray\new_dashboard": "../../dashboard",
++        r"ray\dashboard": "../../dashboard",
+         r"ray\rllib": "../../rllib",
+         r"ray\streaming": "../../streaming/python/",
+     }
+@@ -353,7 +353,7 @@ def replace_symlinks_with_junctions():
+                 os.path.join(os.path.dirname(path), target))
+             logger.info("Setting {} -> {}".format(link, target))
+             subprocess.check_call(
+-                f"MKLINK /J '{os.path.basename(link)}' '{target}'",
++                f'MKLINK /J "{os.path.basename(link)}" "{target}"',
+                 shell=True,
+                 cwd=os.path.dirname(path))
+ 
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
Pretty much all the current patches had to be updated to match with the new sources, and a few can no longer be used because the code has diverged quite a bit - those were removed. Only `ray` and `ray-default` are being packaged here; others have been skipped because apparently Intel doesn't need them.

Concourse build: https://concourse.build.corp.continuum.io/teams/main/pipelines/stiwari_ray