### PR TITLE
Rebuild v2.3.0.b1

### DIFF
--- a/recipe/build-core.bat
+++ b/recipe/build-core.bat
@@ -1,8 +1,11 @@
+bazel clean --expunge
+bazel shutdown
+
 cd python
 set SKIP_THIRDPARTY_INSTALL=1
 set IS_AUTOMATED_BUILD=1
 set "BAZEL_SH=%BUILD_PREFIX%\Library\usr\bin\bash.exe"
-"%PYTHON%" setup.py install
+"%PYTHON%" -m pip install . --no-deps --no-build-isolation
 rem remember the return code
 set RETCODE=%ERRORLEVEL%
 
@@ -11,7 +14,7 @@ rem different Python version) do not stumble on some after-effects.
 "%PYTHON%" setup.py clean --all
 
 rem Now shut down Bazel server, otherwise Windows would not allow moving a directory with it
-bazel "--output_user_root=%SRC_DIR%\..\bazel-root" "--output_base=%SRC_DIR%\..\b-o" clean
+bazel "--output_user_root=%SRC_DIR%\..\bazel-root" "--output_base=%SRC_DIR%\..\b-o" clean --expunge
 bazel "--output_user_root=%SRC_DIR%\..\bazel-root" "--output_base=%SRC_DIR%\..\b-o" shutdown
 rd /s /q "%SRC_DIR%\..\b-o" "%SRC_DIR%\..\bazel-root"
 rem Ignore "bazel shutdown" errors

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -xe
 
+bazel clean --expunge
+bazel shutdown
+
 if [[ "${target_platform}" == osx-* ]]; then
   export LDFLAGS="${LDFLAGS} -lz -framework CoreFoundation -Xlinker -undefined -Xlinker dynamic_lookup"
 else
@@ -28,7 +31,7 @@ grep -lR ELF build/ | xargs chmod +w
 # now clean everything up so subsequent builds (for potentially
 # different Python version) do not stumble on some after-effects
 "${PYTHON}" setup.py clean --all
-bazel "--output_user_root=$SRC_DIR/../bazel-root" "--output_base=$SRC_DIR/../b-o" clean
+bazel "--output_user_root=$SRC_DIR/../bazel-root" "--output_base=$SRC_DIR/../b-o" clean --expunge
 bazel "--output_user_root=$SRC_DIR/../bazel-root" "--output_base=$SRC_DIR/../b-o" shutdown
 rm -rf "$SRC_DIR/../b-o" "$SRC_DIR/../bazel-root"
 # this is needed because on many build systems the cache is actually under /root.

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -xe
 
+if [[ "${target_platform}" == osx-* ]]; then
+  export LDFLAGS="${LDFLAGS} -lz -framework CoreFoundation -Xlinker -undefined -Xlinker dynamic_lookup"
+else
+  export LDFLAGS="${LDFLAGS} -lrt"
+fi
+
 # For some weird reason, ar is not picked up on linux-aarch64
 if [ $(uname -s) = "Linux" ] && [ ! -f "${BUILD_PREFIX}/bin/ar" ]; then
     ln -s "${BUILD}-ar" "${BUILD_PREFIX}/bin/ar"

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -26,7 +26,7 @@ export SKIP_THIRDPARTY_INSTALL=1
 grep -lR ELF build/ | xargs chmod +w
 
 # now install the thing so conda could pick it up
-"${PYTHON}" setup.py install  --single-version-externally-managed --root=/
+${PYTHON} -m pip install . --no-deps --no-build-isolation
 
 # now clean everything up so subsequent builds (for potentially
 # different Python version) do not stumble on some after-effects

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/0013-Add-bazel-linkopts-libs.patch
 
 build:
-  number: 0
+  number: 1
   # py36 is technically supported but we don't want to build for it
   skip: true  # [py<38]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/ray-project/ray/archive/ray-{{ version }}.tar.gz
   sha256: 0554b8711db70fae4c0acc8e01674901a84b81405f5247ed933b12ed047ff353
   patches:
-    - patches/0003-Redis-deps-now-build-but-do-not-link.patch
+    # - patches/0003-Redis-deps-now-build-but-do-not-link.patch
     - patches/0004-Disable-making-non-core-entry-scripts.patch
     - patches/0010-Remove-all-dependencies-from-setup.py.patch
     - patches/0011-Ignore-warnings-in-event.cc-and-logging.cc.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
   skip: true  # [py<38 or py>310]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64.
   # skipping osx and aarch64 for now, as there are complicated bazel errors with external redis (symbols, dependant libraries, and objects).
-  skip: true  # [osx or (linux and (s390x or ppc64le or aarch64))]
+  skip: true  # [(linux and (s390x or ppc64le or aarch64))]
 
 # Need these up here to handle them properly.
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,8 @@ source:
 build:
   number: 1
   # py36 is technically supported but we don't want to build for it
-  skip: true  # [py<38]
+  # ray-core is the only output to support 3.11 at the moment.
+  skip: true  # [py<38 or py>310]
   # skipping architectures that do not yet have bazel, so only build for linux64 & win64.
   # skipping osx and aarch64 for now, as there are complicated bazel errors with external redis (symbols, dependant libraries, and objects).
   skip: true  # [osx or (linux and (s390x or ppc64le or aarch64))]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - m2-patch       # [win]
     - bazel ==4.2.2
     - curl
-    - cython ==0.29.28
+    - cython >=0.29.32
     - git
     - m2-make   # [win]
     - make      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -180,7 +180,7 @@ outputs:
         - cp -R ./build $SP_DIR/ray/dashboard/client/build  # [not win]
     requirements:
       host:
-        - nodejs
+        - nodejs <18
         - python
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
     - patches/0010-Remove-all-dependencies-from-setup.py.patch
     - patches/0011-Ignore-warnings-in-event.cc-and-logging.cc.patch
     - patches/0013-Add-bazel-linkopts-libs.patch
+    # https://github.com/ray-project/ray/pull/34151
+    - patches/0014-fix-namespaces.patch
 
 build:
   number: 1

--- a/recipe/patches/0014-fix-namespaces.patch
+++ b/recipe/patches/0014-fix-namespaces.patch
@@ -1,0 +1,42 @@
+diff --git a/.bazelrc b/.bazelrc
+index a046909696..0931ca89f8 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -44,8 +44,8 @@ build --per_file_copt="\\.pb\\.cc$@-w"
+ # Ignore one specific warning
+ build --per_file_copt="event\\.cc$@-w"
+ build --per_file_copt="logging\\.cc$@-w"
+-build --per_file_copt="-\\.(asm|S)$,external/.*@-w"
+-#build --per_file_copt="external/.*@-Wno-unused-result"
++build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
++build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
+ # Ignore minor warnings for host tools, which we generally can't control
+ build:clang-cl --host_copt="-Wno-inconsistent-missing-override"
+ build:clang-cl --host_copt="-Wno-microsoft-unqualified-friend"
+diff --git a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+index b1bca761d7..5e291f10c1 100644
+--- a/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
++++ b/src/ray/gcs/gcs_server/gcs_placement_group_manager.cc
+@@ -850,7 +850,7 @@ void GcsPlacementGroupManager::UpdatePlacementGroupLoad() {
+       break;
+     }
+   }
+-  gcs_resource_manager_.UpdatePlacementGroupLoad(move(placement_group_load));
++  gcs_resource_manager_.UpdatePlacementGroupLoad(std::move(placement_group_load));
+ }
+ 
+ void GcsPlacementGroupManager::Initialize(const GcsInitData &gcs_init_data) {
+diff --git a/src/ray/thirdparty/dlmalloc.c b/src/ray/thirdparty/dlmalloc.c
+index 62a2a0400c..44bf70fe2c 100644
+--- a/src/ray/thirdparty/dlmalloc.c
++++ b/src/ray/thirdparty/dlmalloc.c
+@@ -521,6 +521,9 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
+   improvement at the expense of carrying around more memory.
+ */
+ 
++#ifdef __clang__
++#pragma clang diagnostic ignored "-Weverything"
++#endif
+ 
+ /* Version identifier to allow people to support multiple versions */
+ #ifndef DLMALLOC_VERSION


### PR DESCRIPTION
- Bump build number
- Fixes building for OSX
- Still skipping `aarch64` due to jemalloc errors compiling redis
- Add patch to fix errors on clang, `std::` needs to be explicit
- skip 3.11: https://github.com/ray-project/ray/milestone/104