### PR TITLE
[PKG-7906] 2.46.0

### DIFF
--- a/recipe/build-core.bat
+++ b/recipe/build-core.bat
@@ -7,6 +7,8 @@ set SKIP_THIRDPARTY_INSTALL=1
 set IS_AUTOMATED_BUILD=1
 set "BAZEL_SH=%BUILD_PREFIX%\Library\usr\bin\bash.exe"
 
+set SKIP_THIRDPARTY_INSTALL_CONDA_FORGE=1
+
 echo ==========================================================
 echo calling pip install
 echo ==========================================================

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -4,6 +4,11 @@ set -xe
 bazel clean --expunge
 bazel shutdown
 
+if [[ "${target_platform}" == osx-64 ]]; then
+  # Fix "too many open files" error
+  ulimit -s 65532
+fi
+
 if [[ "${target_platform}" == linux-aarch64 ]]; then
   # Fix -Werror=stringop-overflow error
   echo 'build --per_file_copt="external/upb/upbc/protoc-gen-upbdefs\.cc@-w"' >> .bazelrc
@@ -39,11 +44,6 @@ if [[ "${target_platform}" == osx-* ]]; then
   echo 'build --per_file_copt="src/ray/.*$@-w"' >> .bazelrc
 else
   export LDFLAGS="${LDFLAGS} -lrt"
-fi
-
-if [[ "${target_platform}" == osx-64 ]]; then
-  # Fix "too many open files" error
-  echo 'build --local_cpu_resources=1' >> .bazelrc
 fi
 
 echo build --linkopt=-static-libstdc++ >> .bazelrc

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -4,16 +4,12 @@ set -xe
 bazel clean --expunge
 bazel shutdown
 
-if [[ "${target_platform}" == osx-64 ]]; then
-  # Fix "too many open files" error
-  ulimit -s 65532
-fi
-
 if [[ "${target_platform}" == linux-aarch64 ]]; then
   # Fix -Werror=stringop-overflow error
   echo 'build --per_file_copt="external/upb/upbc/protoc-gen-upbdefs\.cc@-w"' >> .bazelrc
   echo 'build --host_per_file_copt="external/upb/upbc/protoc-gen-upbdefs\.cc@-w"' >> .bazelrc
-  # Fix memory error
+  # Fix memory error. Stick with 2 cores for now.
+  # Evaluate as the build system changes. 
   echo 'build --local_cpu_resources=2' >> .bazelrc
 fi
 

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -4,6 +4,8 @@ set -xe
 bazel clean --expunge
 bazel shutdown
 
+export SKIP_THIRDPARTY_INSTALL_CONDA_FORGE=1
+
 if [[ "${target_platform}" == linux-aarch64 ]]; then
   # Fix -Werror=stringop-overflow error
   echo 'build --per_file_copt="external/upb/upbc/protoc-gen-upbdefs\.cc@-w"' >> .bazelrc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,25 +1,4 @@
 cuda_compiler_version:                            # [linux and x86_64]
   - None                                          # [linux and x86_64]
-docker_image:                                     # [linux and x86_64]
-  - quay.io/condaforge/linux-anvil-cos7-x86_64    # [linux and x86_64]
 cudnn:                                            # [linux and x86_64]
   - undefined                                     # [linux and x86_64]
-cdt_name:                                         # [linux and x86_64]
-  - cos7                                          # [linux and x86_64]
-
-c_compiler:                                       # [win]
-- vs2019                                          # [win]
-cxx_compiler:                                     # [win]
-- vs2019                                          # [win]
-macos_min_version:
-  - 10.15  # [osx and x86_64]
-  - 11.13  # [osx and arm64]
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.15  # [osx and x86_64]
-  - 11.1  # [osx and arm64]
-MACOSX_SDK_VERSION:        # [osx]
-  - "10.15"                # [osx and x86_64]
-  - "11.1"                 # [osx and arm64]
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -16,10 +16,10 @@ macos_min_version:
   - 11.13  # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:
   - 10.15  # [osx and x86_64]
-  - 11.3  # [osx and arm64]
+  - 11.1  # [osx and arm64]
 MACOSX_SDK_VERSION:        # [osx]
   - "10.15"                # [osx and x86_64]
-  - "11.3"                 # [osx and arm64]
+  - "11.1"                 # [osx and arm64]
 CONDA_BUILD_SYSROOT:
   - /opt/MacOSX10.15.sdk        # [osx and x86_64]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "2.37.0" %}
+{% set version = "2.46.0" %}
 
 package:
   name: ray-packages
   version: {{ version }}
 
 source:
-  url: https://github.com/ray-project/ray/archive/ray-{{ version }}.tar.gz
-  sha256: dcf92302ba813080003f33cb874912ee950331f2348822a2b615eb46f9baf0f8
+  url: https://github.com/ray-project/ray/archive/refs/tags/ray-{{ version }}.tar.gz
+  sha256: 761adac3ea5dd127215e22976e140f0d66ca3bc0e029b2b21136182d0190cf98
   patches:
     - patches/0001-Redis-deps-now-build-but-do-not-link.patch
     - patches/0002-Disable-making-entry-scripts.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
 build:
   number: 0
   skip: true  # [py<39 or py>312]
+  # Skipping OSX-64 for now due to "Too many open files" error. 
+  skip: true  # [(osx and x86_64)]
 
 # The requirements/build&host sections of ray-core need to be replicated here.
 # It is not clear why at this time but not having them here causes conda build to behave non-deterministically and crash. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ source:
 build:
   number: 0
   skip: true  # [py<39 or py>312]
-  skip: true  # [linux and s390x]
 
 # The requirements/build&host sections of ray-core need to be replicated here.
 # It is not clear why at this time but not having them here causes conda build to behave non-deterministically and crash. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -241,8 +241,6 @@ outputs:
 
   - name: ray-rllib
     build:
-      entry_points:
-        - rllib = ray.rllib.scripts:cli
     requirements:
       host:
         - python
@@ -260,12 +258,6 @@ outputs:
     test:
       imports:
         - ray.rllib                                       # [not (osx and arm64)]
-      commands:
-        # some interaction with rich and the test runner in azure
-        # xref https://github.com/Textualize/rich/issues/2411 ?
-        # Skip on osx-arm64 to prevent "Too many open files" error on CI, run tests locally to confirm they pass on OSX
-        - python -c "import subprocess, os; os.environ['PYTHONIOENCODING']='utf-8'; subprocess.run(['rllib', '--help'], capture_output=True, check=True)" # [not (osx and arm64)]
-
   - name: ray-data
     requirements:
       host:

--- a/recipe/patches/0001-Redis-deps-now-build-but-do-not-link.patch
+++ b/recipe/patches/0001-Redis-deps-now-build-but-do-not-link.patch
@@ -8,7 +8,7 @@ Co-authored-by: Gregory Shimansky <gregory.shimansky@intel.com>
 Co-authored-by: Jiajun Yao <jeromeyjj@gmail.com>
 Co-authored-by: H. Vetinari <h.vetinari@gmx.com>
 ---
- bazel/BUILD.redis                             | 13 +++-
+ bazel/redis.BUILD                             | 13 +++-
  bazel/ray_deps_setup.bzl                      |  2 +-
  ...01-keep-redis-quiet-and-override-AR.patch} | 64 +++++++++++++++++--
  3 files changed, 71 insertions(+), 8 deletions(-)
@@ -16,8 +16,8 @@ Co-authored-by: H. Vetinari <h.vetinari@gmx.com>
 
 diff --git a/bazel/BUILD.redis b/bazel/BUILD.redis
 index 68e06a7..818ab93 100644
---- a/bazel/BUILD.redis
-+++ b/bazel/BUILD.redis
+--- a/bazel/redis.BUILD
++++ b/bazel/redis.BUILD
 @@ -42,13 +42,17 @@ make(
  
  genrule_cmd = select({

--- a/recipe/patches/0002-Disable-making-entry-scripts.patch
+++ b/recipe/patches/0002-Disable-making-entry-scripts.patch
@@ -8,23 +8,19 @@ Subject: [PATCH 2/5] Disable making entry scripts
  1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/python/setup.py b/python/setup.py
-index d1566cf14f..c79aca8689 100644
+index d9935f087e..67f2ab1b2d 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -795,10 +795,10 @@ setuptools.setup(
+@@ -728,9 +728,9 @@ setuptools.setup(
      extras_require=setup_spec.extras,
      entry_points={
          "console_scripts": [
 -            "ray=ray.scripts.scripts:main",
--            "rllib=ray.rllib.scripts:cli [rllib]",
 -            "tune=ray.tune.cli.scripts:cli",
 -            "serve=ray.serve.scripts:cli",
 +            #"ray=ray.scripts.scripts:main",
-+            #"rllib=ray.rllib.scripts:cli [rllib]",
 +            #"tune=ray.tune.cli.scripts:cli",
 +            #"serve=ray.serve.scripts:cli",
          ]
      },
      package_data={
--- 
-2.39.2 (Apple Git-143)

--- a/recipe/patches/0003-Add-bazel-linkopts-libs.patch
+++ b/recipe/patches/0003-Add-bazel-linkopts-libs.patch
@@ -9,10 +9,10 @@ Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/python/setup.py b/python/setup.py
-index c79aca8689..affa582097 100644
+index 67f2ab1b2d..30f448740b 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -510,6 +510,8 @@ def build(build_python, build_java, build_cpp):
+@@ -443,6 +443,8 @@ def build(build_python, build_java, build_cpp):
          raise OSError(msg)
  
      bazel_env = dict(os.environ, PYTHON3_BIN_PATH=sys.executable)
@@ -21,5 +21,3 @@ index c79aca8689..affa582097 100644
  
      if is_native_windows_or_msys():
          SHELL = bazel_env.get("SHELL")
--- 
-2.39.2 (Apple Git-143)

--- a/recipe/patches/0004-Ignore-warnings-in-event.cc-and-logging.cc.patch
+++ b/recipe/patches/0004-Ignore-warnings-in-event.cc-and-logging.cc.patch
@@ -10,18 +10,16 @@ Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/.bazelrc b/.bazelrc
-index e81c646c15..f697edbbae 100644
+index 13774dda7c..7db790a4bf 100644
 --- a/.bazelrc
 +++ b/.bazelrc
-@@ -44,6 +44,9 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
+@@ -57,6 +57,9 @@ build:clang-cl --per_file_copt="-\\.(asm|S)$@-Werror"
  build:msvc-cl     --per_file_copt="-\\.(asm|S)$@-WX"
  # Ignore warnings for protobuf generated files and external projects.
  build --per_file_copt="\\.pb\\.cc$@-w"
 +# Ignore one specific warning
 +build --per_file_copt="event\\.cc$@-w"
 +build --per_file_copt="logging\\.cc$@-w"
- build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
- build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration"
- # Ignore minor warnings for host tools, which we generally can't control
--- 
-2.39.2 (Apple Git-143)
+ build:linux --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=unused-function"
+ build:macos --per_file_copt="-\\.(asm|S)$,external/.*@-w,-Wno-error=implicit-function-declaration,-Wno-error=unused-function,-Wno-missing-template-arg-list-after-template-kw"
+ # Ignore warnings for host tools, which we generally can't control.

--- a/recipe/patches/0005-Remove-all-dependencies-from-setup.py.patch
+++ b/recipe/patches/0005-Remove-all-dependencies-from-setup.py.patch
@@ -11,31 +11,34 @@ Co-authored-by: Matti Picus <matti.picus@gmail.com>
  1 file changed, 9 insertions(+), 101 deletions(-)
 
 diff --git a/python/setup.py b/python/setup.py
-index 3898eb6..69573de 100644
+index 838f3aa744..d9935f087e 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -225,100 +225,19 @@ ray_files += [
+@@ -225,112 +225,18 @@ ray_files += [
  # also update the matching section of requirements/requirements.txt
  # in this directory
  if setup_spec.type == SetupType.RAY:
 -    pandas_dep = "pandas >= 1.3"
 -    numpy_dep = "numpy >= 1.20"
--    pyarrow_dep = "pyarrow >= 6.0.1"
+-    pyarrow_deps = [
+-        "pyarrow >= 9.0.0",
+-        "pyarrow <18; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+-    ]
+-    pydantic_dep = "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3"
      setup_spec.extras = {
--        "adag": [
+-        "cgraph": [
 -            "cupy-cuda12x; sys_platform != 'darwin'",
 -        ],
 -        "client": [
 -            # The Ray client needs a specific range of gRPC to work:
 -            # Tracking issues: https://github.com/grpc/grpc/issues/33714
--            "grpcio != 1.56.0"
--            if sys.platform == "darwin"
--            else "grpcio",
+-            "grpcio != 1.56.0; sys_platform == 'darwin'",
+-            "grpcio",
 -        ],
 -        "data": [
 -            numpy_dep,
 -            pandas_dep,
--            pyarrow_dep,
+-            *pyarrow_deps,
 -            "fsspec",
 -        ],
 -        "default": [
@@ -44,21 +47,22 @@ index 3898eb6..69573de 100644
 -            "aiohttp >= 3.7",
 -            "aiohttp_cors",
 -            "colorful",
--            "py-spy >= 0.2.0",
+-            "py-spy >= 0.2.0; python_version < '3.12'",  # noqa:E501
+-            "py-spy >= 0.4.0; python_version >= '3.12'",  # noqa:E501
 -            "requests",
 -            "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
 -            "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
 -            "opencensus",
--            "pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3",
+-            pydantic_dep,
 -            "prometheus_client >= 0.7.1",
 -            "smart_open",
 -            "virtualenv >=20.0.24, !=20.21.1",  # For pip runtime env.
--            "memray; sys_platform != 'win32'",
 -        ],
 -        "observability": [
 -            "opentelemetry-api",
 -            "opentelemetry-sdk",
 -            "opentelemetry-exporter-otlp",
+-            "memray; sys_platform != 'win32'",
 -        ],
 -        "serve": [
 -            "uvicorn[standard]",
@@ -67,16 +71,26 @@ index 3898eb6..69573de 100644
 -            "fastapi",
 -            "watchfiles",
 -        ],
--        "tune": ["pandas", "tensorboardX>=1.9", "requests", pyarrow_dep, "fsspec"],
-+        "adag": [],
+-        "tune": [
+-            "pandas",
+-            "tensorboardX>=1.9",
+-            "requests",
+-            *pyarrow_deps,
+-            "fsspec",
+-        ],
++        "cgraph": [],
 +        "client": [],
 +        "data": [],
 +        "default": [],
 +        "observability": [],
 +        "serve": [],
-+        "tune": [],
++        "tune": []
      }
- 
+-
+-    # Both "adag" and "cgraph" are for Compiled Graphs.
+-    # "adag" is deprecated and will be removed in the future.
+-    setup_spec.extras["adag"] = list(setup_spec.extras["cgraph"])
+-
 -    # Ray Serve depends on the Ray dashboard components.
 -    setup_spec.extras["serve"] = list(
 -        set(setup_spec.extras["serve"] + setup_spec.extras["default"])
@@ -89,6 +103,7 @@ index 3898eb6..69573de 100644
 -            + [
 -                "grpcio >= 1.32.0; python_version < '3.10'",  # noqa:E501
 -                "grpcio >= 1.42.0; python_version >= '3.10'",  # noqa:E501
+-                "pyOpenSSL",
 -            ]
 -        )
 -    )
@@ -98,16 +113,14 @@ index 3898eb6..69573de 100644
  
 -    setup_spec.extras["rllib"] = setup_spec.extras["tune"] + [
 -        "dm_tree",
--        "gymnasium==0.28.1",
+-        "gymnasium==1.0.0",
 -        "lz4",
--        "scikit-image",
+-        "ormsgpack==1.7.0",
 -        "pyyaml",
 -        "scipy",
--        "typer",
--        "rich",
 -    ]
 -
--    setup_spec.extras["train"] = setup_spec.extras["tune"]
+-    setup_spec.extras["train"] = setup_spec.extras["tune"] + [pydantic_dep]
 -
 -    # Ray AI Runtime should encompass Data, Tune, and Serve.
 -    setup_spec.extras["air"] = list(
@@ -118,11 +131,10 @@ index 3898eb6..69573de 100644
 -            + setup_spec.extras["serve"]
 -        )
 -    )
--
-     # "all" will not include "cpp" anymore. It is a big depedendency
-     # that most people do not need.
-     #
-@@ -341,18 +260,7 @@ if setup_spec.type == SetupType.RAY:
+ 
+     # NOTE: While we keep ray[all] for compatibility, you probably
+     # shouldn't use it because it contains too many dependencies
+@@ -385,17 +291,7 @@ if setup_spec.type == SetupType.RAY:
  # install-core-prerelease-dependencies.sh so we can test
  # new releases candidates.
  if setup_spec.type == SetupType.RAY:
@@ -134,23 +146,19 @@ index 3898eb6..69573de 100644
 -        "packaging",
 -        "protobuf >= 3.15.3, != 3.19.5",
 -        "pyyaml",
--        "aiosignal",
--        "frozenlist",
 -        "requests",
 -    ]
+-
 +    setup_spec.install_requires = []
  
- 
  def is_native_windows_or_msys():
-@@ -797,7 +705,7 @@ setuptools.setup(
+     """Check to see if we are running on native Windows,
+@@ -828,7 +724,7 @@ setuptools.setup(
      # The BinaryDistribution argument triggers build_ext.
      distclass=BinaryDistribution,
      install_requires=setup_spec.install_requires,
--    setup_requires=["cython >= 0.29.32", "wheel"],
+-    setup_requires=["cython >= 3.0.12", "pip", "wheel"],
 +    setup_requires=[],
      extras_require=setup_spec.extras,
      entry_points={
          "console_scripts": [
--- 
-2.45.2
-

--- a/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
+++ b/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Don't build redis with jemalloc on linux-aarch64 to avoid a
 LINK redis-server
 defrag.o:defrag.c:function activeDefragAlloc: error: undefined reference to 'je_get_defrag_hint'
 ---
- bazel/BUILD.redis | 1 +
+ bazel/redis.BUILD | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/bazel/BUILD.redis b/bazel/BUILD.redis
+diff --git a/bazel/redis.BUILD b/bazel/redis.BUILD
 index 9edccf5780..d0087f8531 100644
 --- a/bazel/BUILD.redis
 +++ b/bazel/BUILD.redis

--- a/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
+++ b/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
@@ -11,7 +11,7 @@ defrag.o:defrag.c:function activeDefragAlloc: error: undefined reference to 'je_
  1 file changed, 1 insertion(+)
 
 diff --git a/bazel/redis.BUILD b/bazel/redis.BUILD
-index 9edccf5780..d0087f8531 100644
+index bdb69b7a39..3cf8b4a017 100644
 --- a/bazel/BUILD.redis
 +++ b/bazel/BUILD.redis
 @@ -21,6 +21,7 @@ make(

--- a/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
+++ b/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
@@ -12,8 +12,8 @@ defrag.o:defrag.c:function activeDefragAlloc: error: undefined reference to 'je_
 
 diff --git a/bazel/redis.BUILD b/bazel/redis.BUILD
 index bdb69b7a39..3cf8b4a017 100644
---- a/bazel/BUILD.redis
-+++ b/bazel/BUILD.redis
+--- a/bazel/redis.BUILD
++++ b/bazel/redis.BUILD
 @@ -21,6 +21,7 @@ make(
      name = "redis",
      args = [

--- a/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
+++ b/recipe/patches/0015-Don-t-build-redis-with-jemalloc-on-linux-aarch64.patch
@@ -11,7 +11,7 @@ defrag.o:defrag.c:function activeDefragAlloc: error: undefined reference to 'je_
  1 file changed, 1 insertion(+)
 
 diff --git a/bazel/redis.BUILD b/bazel/redis.BUILD
-index bdb69b7a39..3cf8b4a017 100644
+index bdb69b7a39..0d2a003f26 100644
 --- a/bazel/redis.BUILD
 +++ b/bazel/redis.BUILD
 @@ -21,6 +21,7 @@ make(
@@ -22,6 +22,16 @@ index bdb69b7a39..3cf8b4a017 100644
          "-s",
      ],
      copts = [
+@@ -29,6 +30,9 @@ make(
+         "-Wno-empty-body",
+         "-fPIC",
+     ],
++    env = {
++        "PATH": "$$BUILD_PREFIX/bin:$$PATH",
++    },
+     visibility = ["//visibility:public"],
+     lib_source = ":all_srcs",
+     deps = [
 -- 
 2.42.0
 

--- a/recipe/patches/0016-fix-redis-build-on-macos.patch
+++ b/recipe/patches/0016-fix-redis-build-on-macos.patch
@@ -8,10 +8,10 @@ Co-authored-by: Jean-Christophe Morin <jcmorin@anaconda.com>
  bazel/BUILD.redis | 10 +++++-----
  1 file changed, 5 insertions(+), 5 deletions(-)
 
-diff --git a/bazel/BUILD.redis b/bazel/BUILD.redis
+diff --git a/bazel/redis.BUILD b/bazel/redis.BUILD
 index 818ab93..4adfd13 100644
---- a/bazel/BUILD.redis
-+++ b/bazel/BUILD.redis
+--- a/bazel/redis.BUILD
++++ b/bazel/redis.BUILD
 @@ -42,17 +42,17 @@ make(
  
  genrule_cmd = select({

--- a/recipe/patches/0018-Remove-runtime-agent-dependencies.patch
+++ b/recipe/patches/0018-Remove-runtime-agent-dependencies.patch
@@ -8,30 +8,28 @@ Subject: [PATCH] Remove runtime agent dependencies
  1 file changed, 14 deletions(-)
 
 diff --git a/python/setup.py b/python/setup.py
-index 3898eb6..3e21bb7 100644
+index 30f448740b..6c45afe990 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -542,20 +542,6 @@ def build(build_python, build_java, build_cpp):
+@@ -482,21 +482,6 @@ def build(build_python, build_java, build_cpp):
              env=dict(os.environ, CC="gcc"),
          )
  
--    # runtime env agent dependenceis
--    runtime_env_agent_pip_packages = ["aiohttp"]
--    subprocess.check_call(
--        [
--            sys.executable,
--            "-m",
--            "pip",
--            "install",
--            "-q",
--            "--target=" + os.path.join(ROOT_DIR, RUNTIME_ENV_AGENT_THIRDPARTY_SUBDIR),
--        ]
--        + runtime_env_agent_pip_packages
--    )
+-        # runtime env agent dependenceis
+-        runtime_env_agent_pip_packages = ["aiohttp"]
+-        subprocess.check_call(
+-            [
+-                sys.executable,
+-                "-m",
+-                "pip",
+-                "install",
+-                "-q",
+-                "--target="
+-                + os.path.join(ROOT_DIR, RUNTIME_ENV_AGENT_THIRDPARTY_SUBDIR),
+-            ]
+-            + runtime_env_agent_pip_packages
+-        )
 -
      bazel_flags = ["--verbose_failures"]
      if BAZEL_ARGS:
          bazel_flags.extend(shlex.split(BAZEL_ARGS))
--- 
-2.45.2
-


### PR DESCRIPTION
ray 2.46.0

**Destination channel:** defaults

### Links

- [PKG-7906]
- [Upstream repository](https://github.com/ray-project/ray/tree/ray-2.46.0)

### Explanation of changes:

- Bump version and SHA
- Rebase patches
- Switch from `SKIP_THIRDPARTY_INSTALL` to `SKIP_THIRDPARTY_INSTALL_CONDA_FORGE` to [match upstream ](https://github.com/ray-project/ray/blob/ray-2.46.0/python/setup.py#L572)
- Numerous work-arounds for linux-aarch64. 
- Disable osx-64: Unless we have a specific need for it in the future, it was decided it wasn't worth more than a day troubleshooting "too many open files". Things I tried:
    - Enabling only a single job (this led to the failure happening in 14 hours instead of 2)
    - Re-trying numerous times
    - `ulimit -s unlimited` : Didn't work at all
    - `ulimit -s 65532` where 65532 is what was returned from `ulimit -Hs` as the maximum
- rllib entry point was removed upstream. 

[PKG-7906]: https://anaconda.atlassian.net/browse/PKG-7906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ