### PR TITLE
ray-packages 2.46.0 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,8 @@ source:
     - patches/0018-Remove-runtime-agent-dependencies.patch
 
 build:
-  number: 1
-  # All Python versions are breaking the CI. Temporarily, only Python 3.13 will be used to rebuild and release these artifacts.
-  skip: true  # [py<313]
+  number: 0
+  skip: true  # [py<39]
   # Skipping OSX-64 for now due to "Too many open files" error. 
   skip: true  # [(osx and x86_64)]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,8 @@ source:
 
 build:
   number: 1
-  skip: true  # [py<39]
+  # All Python versions are breaking the CI. Temporarily, only Python 3.13 will be used to rebuild and release these artifacts.
+  skip: true  # [py<313]
   # Skipping OSX-64 for now due to "Too many open files" error. 
   skip: true  # [(osx and x86_64)]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,8 @@ source:
     - patches/0018-Remove-runtime-agent-dependencies.patch
 
 build:
-  number: 0
-  skip: true  # [py<39 or py>312]
+  number: 1
+  skip: true  # [py<39]
   # Skipping OSX-64 for now due to "Too many open files" error. 
   skip: true  # [(osx and x86_64)]
 


### PR DESCRIPTION
ray-packages 2.46.0 

**Destination channel:** Defaults

### Links

- [PKG-9257]
- dev_url:        https://github.com/ray-project/ray/tree/ray-2.46.0
- conda_forge:    https://github.com/conda-forge/ray-packages-feedstock
- pypi:           https://pypi.org/project/ray-packages/2.46.0
- pypi inspector: https://inspector.pypi.io/project/ray-packages/2.46.0/

### Explanation of changes:

- ray-packages 2.46.0 rebuild to release py3.13 package
- build number is the same, its the trick which trigger building artifacts only for missing python


[PKG-9257]: https://anaconda.atlassian.net/browse/PKG-9257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ