### PR TITLE
update to 2.57.0

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -10,6 +10,7 @@ upstream_sources:
     packages:
       - ray-adag
       - ray-air
+      - ray-all
       - ray-client
       - ray-core
       - ray-dashboard

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ray-packages" %}
-{% set version = "2.56.1" %}
+{% set version = "2.57.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name.split('-')[0] }}-project/{{ name.split('-')[0] }}/archive/refs/tags/{{ name.split('-')[0] }}-{{ version }}.tar.gz
-  sha256: 07d26c88622bea9b92d034aa743600f59e9311b934ac953bd15e7418b9fe31bb
+  sha256: 75b8ab2eab971b4c1bfb1bbe1c4636951b746c04a2541f02d0ce0716189f547c
   patches:
     - patches/0001-Redis-deps-now-build-but-do-not-link.patch
     - patches/0002-Disable-making-entry-scripts.patch
@@ -28,7 +28,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<310]
+  # Upstream SUPPORTED_PYTHONS is 3.10-3.14 (python/setup.py); setup.py hard-fails outside it.
+  skip: true  # [py<310 or py>314]
 
 # The requirements/build&host sections of ray-core need to be replicated here.
 # It is not clear why at this time but not having them here causes conda build to behave non-deterministically and crash. 
@@ -52,7 +53,6 @@ requirements:
     - python
     - pip
     - cython >=3.0.12
-    - pkg-config  # [osx]
     - setuptools
     - wheel
     - openjdk =11
@@ -90,8 +90,7 @@ outputs:
     script: build-core.sh  # [not win]
     script: build-core.bat  # [win]
     build:
-      skip: true  # [py<310]
-    build:
+      skip: true  # [py<310 or py>314]
       entry_points:
         - ray = ray.scripts.scripts:main
       # Skip overlinking check for _raylet.so: Bazel-built binary uses ELF dynamic
@@ -122,8 +121,7 @@ outputs:
       host:
         - python
         - pip
-        - cython >=0.29.32
-        - pkg-config  # [osx]
+        - cython >=3.0.12
         - setuptools
         - wheel
         - openjdk =11
@@ -156,7 +154,7 @@ outputs:
 
   - name: ray-default
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or py>314]
     requirements:
       host:
         - python
@@ -196,7 +194,7 @@ outputs:
         - cp -R ./build $SP_DIR/ray/dashboard/client/build  # [not win]
     requirements:
       host:
-        - nodejs
+        - nodejs  # analint: host_section_needs_exact_pinnings  # build-time npm toolchain only; no ABI link, version-insensitive
         - python
       run:
         - python
@@ -289,6 +287,9 @@ outputs:
         - fastapi >=0.133.0
         - watchfiles
         - mmh3
+        # Upstream serve extra also lists ray-haproxy (GPLv2 prebuilt haproxy binary wheel, linux-only).
+        # Omitted: import is try/except-guarded with a system-PATH fallback, and the HAProxy router
+        # is feature-flagged off by default (RAY_SERVE_ENABLE_HA_PROXY=0).
     test:
       imports:
         - ray.serve
@@ -424,6 +425,14 @@ about:
   dev_url: https://github.com/ray-project/ray
 
 extra:
+  skip-lints:
+    # top-level ray-packages is a multi-output shell (no artifact); every shipped output has its own test block
+    - missing_imports_or_run_test_py
+    # false positive: build-core.bat's pip install does pass --no-deps --no-build-isolation
+    - pip_install_args
+    # ray-dashboard uses an inline command list under build/script (outputs/x/script only takes a
+    # file name); a per-line analint directive on that key breaks the linter's variant parsing
+    - wrong_output_script_key
   recipe-maintainers:
     - dHannasch
     - h-vetinari

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -169,6 +169,10 @@ outputs:
         - requests
         - grpcio >=1.42.0
         - opencensus
+        # opencensus imports google.rpc from googleapis-common-protos; builds <1.57 ship pre-protobuf-3.19
+        # gencode that crashes on modern runtimes ("Descriptors cannot be created directly").
+        # The floor also keeps protobuf <7 in the env via googleapis-common-protos' own protobuf cap.
+        - googleapis-common-protos >=1.57
         - opentelemetry-sdk >=1.30.0
         - opentelemetry-exporter-prometheus
         - opentelemetry-proto

--- a/recipe/patches/0005-Remove-all-dependencies-from-setup.py.patch
+++ b/recipe/patches/0005-Remove-all-dependencies-from-setup.py.patch
@@ -7,11 +7,9 @@ Subject: [PATCH] Removed all dependencies from setup.py
  python/setup.py | 131 ++++--------------------------------------------
  1 file changed, 9 insertions(+), 122 deletions(-)
 
-diff --git a/python/setup.py b/python/setup.py
-index 03038c7..dd3a8e3 100644
 --- a/python/setup.py
 +++ b/python/setup.py
-@@ -218,96 +218,16 @@ ray_files += [
+@@ -218,97 +218,16 @@ ray_files += [
  # also update the matching section of requirements/requirements.txt
  # in this directory
  if setup_spec.type == SetupType.RAY:
@@ -77,6 +75,7 @@ index 03038c7..dd3a8e3 100644
 -            "fastapi >= 0.133.0",  # >= 0.133.0 required for starlette >= 1.0.
 -            "watchfiles",
 -            "mmh3",
+-            "ray-haproxy>=2.8.25,<2.9.0; sys_platform == 'linux'",
 -        ],
 -        "tune": [
 -            # TODO: Remove pydantic dependency from tune once tune doesn't import train
@@ -115,7 +114,7 @@ index 03038c7..dd3a8e3 100644
      # This is required for supporting the asynchronous inference, allowing the ray serve applications to
      # allow asynchronously execute their code, via the use of celery task processor.
      setup_spec.extras["serve-async-inference"] = list(
-@@ -322,30 +242,6 @@ if setup_spec.type == SetupType.RAY:
+@@ -323,30 +242,6 @@ if setup_spec.type == SetupType.RAY:
  
      setup_spec.extras["cpp"] = ["ray-cpp==" + setup_spec.version]
  
@@ -146,7 +145,7 @@ index 03038c7..dd3a8e3 100644
      # NOTE: While we keep ray[all] for compatibility, you probably
      # shouldn't use it because it contains too many dependencies
      # and no deployment needs all of them. Instead you should list
-@@ -403,16 +299,7 @@ if setup_spec.type == SetupType.RAY:
+@@ -404,16 +299,7 @@ if setup_spec.type == SetupType.RAY:
  # install-core-prerelease-dependencies.sh so we can test
  # new releases candidates.
  if setup_spec.type == SetupType.RAY:
@@ -164,7 +163,7 @@ index 03038c7..dd3a8e3 100644
  
  
  def is_native_windows_or_msys():
-@@ -841,7 +728,7 @@ if __name__ == "__main__":
+@@ -842,7 +728,7 @@ if __name__ == "__main__":
              BinaryDistribution if setup_spec.build_type != BuildType.DEPS_ONLY else None
          ),
          install_requires=setup_spec.install_requires,
@@ -173,5 +172,3 @@ index 03038c7..dd3a8e3 100644
          extras_require=setup_spec.extras,
          entry_points={
              "console_scripts": [
--- 
-2.39.5 (Apple Git-154)

--- a/recipe/patches/0019-Vendor-grpc-1.67.1.patch
+++ b/recipe/patches/0019-Vendor-grpc-1.67.1.patch
@@ -13,8 +13,6 @@ Subject: [PATCH] Vendor grpc 1.67.1
  thirdparty/patches/grpc-zlib-fdopen.patch     |  9 ++++----
  7 files changed, 30 insertions(+), 33 deletions(-)
 
-diff --git a/bazel/ray_deps_setup.bzl b/bazel/ray_deps_setup.bzl
-index f140008..3446800 100644
 --- a/bazel/ray_deps_setup.bzl
 +++ b/bazel/ray_deps_setup.bzl
 @@ -117,13 +117,8 @@ def ray_deps_setup():
@@ -33,7 +31,7 @@ index f140008..3446800 100644
      )
  
      # NOTE(lingxuan.zlx): 3rd party dependencies could be accessed, so it suggests
-@@ -299,8 +294,8 @@ def ray_deps_setup():
+@@ -325,8 +320,8 @@ def ray_deps_setup():
      # TODO(owner): Upgrade abseil to latest version after protobuf updated, which requires to upgrade `rules_cc` first.
      auto_http_archive(
          name = "com_google_absl",
@@ -44,7 +42,7 @@ index f140008..3446800 100644
          patches = [
              # TODO (israbbani): #55430 Separate the compiler flags and remove this patch
              "@io_ray//thirdparty/patches:abseil-cpp-shadow.patch",
-@@ -324,8 +319,8 @@ def ray_deps_setup():
+@@ -350,8 +345,8 @@ def ray_deps_setup():
      auto_http_archive(
          name = "com_github_grpc_grpc",
          # NOTE: If you update this, also update @boringssl's hash.
@@ -55,7 +53,7 @@ index f140008..3446800 100644
          patches = [
              "@io_ray//thirdparty/patches:grpc-cython-copts.patch",
              # Work around bazelbuild/bazel#21592: with layering_check and
-@@ -375,11 +370,11 @@ def ray_deps_setup():
+@@ -401,11 +396,11 @@ def ray_deps_setup():
      auto_http_archive(
          # This rule is used by @com_github_grpc_grpc, and using a GitHub mirror
          # provides a deterministic archive hash for caching. Explanation here:
@@ -70,11 +68,9 @@ index f140008..3446800 100644
      )
  
      # The protobuf version we use to auto generate python and java code.
-diff --git a/src/ray/core_worker/tests/task_event_buffer_export_event_test.cc b/src/ray/core_worker/tests/task_event_buffer_export_event_test.cc
-index 217786f..28faccd 100644
 --- a/src/ray/core_worker/tests/task_event_buffer_export_event_test.cc
 +++ b/src/ray/core_worker/tests/task_event_buffer_export_event_test.cc
-@@ -152,7 +152,7 @@ TEST_F(TaskEventTestWriteExport, TestWriteTaskExportEvents) {
+@@ -155,7 +155,7 @@ TEST_F(TaskEventTestWriteExport, TestWri
    auto task_ids = GenTaskIDs(num_events);
    google::protobuf::util::JsonPrintOptions options;
    options.preserve_proto_field_names = true;
@@ -83,11 +79,9 @@ index 217786f..28faccd 100644
  
    std::vector<SourceTypeVariant> source_types = {
        rpc::ExportEvent_SourceType::ExportEvent_SourceType_EXPORT_TASK};
-diff --git a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
-index 01be481..dc078d3 100644
 --- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
 +++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
-@@ -1264,7 +1264,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
+@@ -1619,7 +1619,7 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
      request.mutable_filters()->set_actor_id(actor->GetActorID().Binary());
  
      auto &reply =
@@ -96,7 +90,7 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
      ASSERT_EQ(reply.actor_table_data().size(), 1);
      ASSERT_EQ(reply.total(), 1 + num_other_actors);
-@@ -1277,7 +1277,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
+@@ -1632,7 +1632,7 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
      request.mutable_filters()->set_job_id(job_id.Binary());
  
      auto &reply =
@@ -105,7 +99,7 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
      ASSERT_EQ(reply.actor_table_data().size(), 1);
      ASSERT_EQ(reply.num_filtered(), num_other_actors);
-@@ -1289,7 +1289,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
+@@ -1644,7 +1644,7 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
      request.mutable_filters()->set_state(rpc::ActorTableData::ALIVE);
  
      auto &reply =
@@ -114,7 +108,7 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
      ASSERT_EQ(reply.actor_table_data().size(), 1);
      ASSERT_EQ(reply.num_filtered(), num_other_actors);
-@@ -1302,7 +1302,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
+@@ -1657,7 +1657,7 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
      request.mutable_filters()->set_job_id(job_id.Binary());
  
      auto &reply =
@@ -123,7 +117,7 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
      ASSERT_EQ(reply.actor_table_data().size(), 1);
      ASSERT_EQ(reply.num_filtered(), num_other_actors);
-@@ -1313,7 +1313,7 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoFilters) {
+@@ -1668,7 +1668,7 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
      request.mutable_filters()->set_job_id(job_id.Binary());
  
      auto &reply =
@@ -132,7 +126,7 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply, callback);
      ASSERT_EQ(reply.num_filtered(), num_other_actors + 1);
      ASSERT_EQ(reply.actor_table_data().size(), 0);
-@@ -1336,14 +1336,14 @@ TEST_F(GcsActorManagerTest, TestGetAllActorInfoLimit) {
+@@ -1691,14 +1691,14 @@ TEST_F(GcsActorManagerTest, TestGetAllAc
    {
      rpc::GetAllActorInfoRequest request;
      auto &reply =
@@ -149,24 +143,20 @@ index 01be481..dc078d3 100644
      gcs_actor_manager_->HandleGetAllActorInfo(request, &reply_2, callback);
      ASSERT_EQ(reply_2.actor_table_data().size(), 2);
      ASSERT_EQ(reply_2.total(), 3);
-diff --git a/src/ray/rpc/server_call.h b/src/ray/rpc/server_call.h
-index 9e6f13c..fe8fd35 100644
 --- a/src/ray/rpc/server_call.h
 +++ b/src/ray/rpc/server_call.h
-@@ -196,7 +196,7 @@ class ServerCallImpl : public ServerCall {
-         auth_token_(auth_token),
+@@ -213,7 +213,7 @@ class ServerCallImpl : public ServerCall
          start_time_(0),
-         record_metrics_(record_metrics) {
+         record_metrics_(record_metrics),
+         server_metrics_(server_metrics) {
 -    reply_ = google::protobuf::Arena::CreateMessage<Reply>(&arena_);
 +    reply_ = google::protobuf::Arena::Create<Reply>(&arena_);
      // TODO(Yi Cheng) call_name_ sometimes get corrunpted due to memory issues.
      RAY_CHECK(!call_name_.empty()) << "Call name is empty";
      if (record_metrics_) {
-diff --git a/src/ray/util/event.cc b/src/ray/util/event.cc
-index efdd53f..8dd4c30 100644
 --- a/src/ray/util/event.cc
 +++ b/src/ray/util/event.cc
-@@ -138,7 +138,7 @@ std::string LogEventReporter::ExportEventToString(const rpc::ExportEvent &export
+@@ -138,7 +138,7 @@ std::string LogEventReporter::ExportEven
    google::protobuf::util::JsonPrintOptions options;
    options.preserve_proto_field_names = true;
    // Required so enum with value 0 is not omitted
@@ -175,8 +165,6 @@ index efdd53f..8dd4c30 100644
    if (export_event.has_task_event_data()) {
      RAY_CHECK(google::protobuf::util::MessageToJsonString(
                    export_event.task_event_data(), &event_data_as_string, options)
-diff --git a/thirdparty/patches/grpc-configurable-thread-count.patch b/thirdparty/patches/grpc-configurable-thread-count.patch
-index e17e111..f0aa4f7 100644
 --- a/thirdparty/patches/grpc-configurable-thread-count.patch
 +++ b/thirdparty/patches/grpc-configurable-thread-count.patch
 @@ -1,7 +1,7 @@
@@ -207,8 +195,6 @@ index e17e111..f0aa4f7 100644
 -     gpr_log(GPR_ERROR, "Cannot determine number of CPUs: assuming 1");
 +     LOG(ERROR) << "Cannot determine number of CPUs: assuming 1";
       ncpus = 1;
-diff --git a/thirdparty/patches/grpc-zlib-fdopen.patch b/thirdparty/patches/grpc-zlib-fdopen.patch
-index 83dfba2..05fd698 100644
 --- a/thirdparty/patches/grpc-zlib-fdopen.patch
 +++ b/thirdparty/patches/grpc-zlib-fdopen.patch
 @@ -1,9 +1,10 @@
@@ -226,6 +212,3 @@ index 83dfba2..05fd698 100644
               ],
  +            patches = [
  +                "@io_ray//thirdparty/patches:zlib-fdopen.patch",
--- 
-2.39.5 (Apple Git-154)
-


### PR DESCRIPTION
ray-packages 2.57.0

**Destination channel:** defaults

### Links
- [PKG-17144](https://anaconda.atlassian.net/browse/PKG-17144)
- [Release notes](https://github.com/ray-project/ray/releases/tag/ray-2.57.0)
- [PyPI](https://pypi.org/project/ray/2.57.0/)

### Explanation of changes:
- Updated ray-packages from 2.56.1 to 2.57.0 
- Note: pkgs/main linux-64 currently indexes ray at 2.54.0 (the 2.56.1 release only partially indexed on linux-64); this release brings all four platforms back to the same latest version.

[PKG-17144]: https://anaconda.atlassian.net/browse/PKG-17144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
